### PR TITLE
Removes `version` from Linux

### DIFF
--- a/scc/map.jinja
+++ b/scc/map.jinja
@@ -4,11 +4,10 @@
     with 'base', and merged with the pillar dictionary 'scc:lookup'.
 -#}
 
-{%- set version = salt.pillar.get('scc:lookup:version', '4.0.1') -%}
+{%- set version = salt.pillar.get('scc:lookup:version', '') -%}
 
 {%- set scc = salt['grains.filter_by']({
     'base': {
-        'version' : version,
         'outputdir' : '',
         'content' : [],
         'pkg' : {},
@@ -19,13 +18,15 @@
         'cmd' : 'cscc.bat',
         'cachedir' : opts['cachedir'] ~ '\\files\\base\\scc\\sccfiles',
         'ossep' : '\\',
+        'version' : version,
     },
     'RedHat' : {
         'name' : 'spawarscc',
         'cwd' : '/opt/scc',
         'cmd' : './cscc',
         'cachedir' : opts['cachedir'] ~ '/files/base/scc/sccfiles',
-        'ossep' : '/'
+        'ossep' : '/',
+        'version' : '',
     } },
     grain='os_family',
     merge=salt['pillar.get']('scc:lookup', {}),


### PR DESCRIPTION
Since the Linux state uses `sources`, version is ignored and results
in a warning. This sets the pkg.version key to an empty string on
Linux, so the if statement in init.sls skips the parameter.